### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,9 +21,6 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
-    @user = User.find(@item.user_id)
-    @province = Prefecture.find(@item.province_id)
-    @day = Day.find(@item.days_id)
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new
@@ -17,6 +17,13 @@ class ItemsController < ApplicationController
       render action: :new
 
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
+    @user = User.find(@item.user_id)
+    @province = Prefecture.find(@item.province_id)
+    @day = Day.find(@item.days_id)
   end
 
   private

--- a/app/models/days.rb
+++ b/app/models/days.rb
@@ -1,4 +1,4 @@
-class Day < ActiveHash::Base
+class Days < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '1~2日で発送' },

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,7 +11,7 @@ class Item < ApplicationRecord
   validates :name, :detail, :category_id, :state_id, :fee_id, :province_id, :days_id,  :price, :image, presence: true
 
   validates :category_id, :state_id, :fee_id, :days_id, numericality: { other_than: 1, base: 'カテゴリを選択してください' }
-  validates :province_id, numericality: {other_than: 0, base: '都道府県を選択してください'}
+  validates :province_id, numericality: { other_than: 0, base: '都道府県を選択してください'}
   validates :price, numericality: {greater_than_or_equal_to: 300, message: '価格は300円以上9,999,999円以下で入力してください'}
   validates :price, numericality: {less_than_or_equal_to: 9_999_999, message: '価格は300円以上9,999,999円以下で入力してください'}
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,8 +4,8 @@ class Item < ApplicationRecord
   belongs_to_active_hash :category
   belongs_to_active_hash :state
   belongs_to_active_hash :fee
-  belongs_to_active_hash :prefecture
-  belongs_to_active_hash :day
+  belongs_to_active_hash :province
+  belongs_to_active_hash :days
   has_one_attached :image
 
   validates :name, :detail, :category_id, :state_id, :fee_id, :province_id, :days_id,  :price, :image, presence: true

--- a/app/models/province.rb
+++ b/app/models/province.rb
@@ -1,4 +1,4 @@
-class Prefecture < ActiveHash::Base
+class Province < ActiveHash::Base
   self.data = [
     {id: 0, name: '--'}, {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
     {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,29 +129,29 @@
       <% @items.each do |item| %>
         <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
         <li class='list'>
-          <%= link_to "#" do %>
-          <div class='item-img-content'>
-            <%= image_tag item.image, class: "item-img" if item.image.attached? %>
+          <%= link_to item_path(item.id) do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
-            <%# 商品が売れていればsold outを表示しましょう %>
-            <div class='sold-out'>
-              <span>Sold Out!!</span>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+              <%# //商品が売れていればsold outを表示しましょう %>
+
             </div>
-            <%# //商品が売れていればsold outを表示しましょう %>
-
-          </div>
-          <div class='item-info'>
-            <h3 class='item-name'>
-              <%= item.name %>
-            </h3>
-            <div class='item-price'>
-              <span><%= item.price %>円<br>(税込み)</span>
-              <div class='star-btn'>
-                <%= image_tag "star.png", class:"star-icon" %>
-                <span class='star-count'>0</span>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
               </div>
             </div>
-          </div>
           <% end %>
         </li>
         <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
@@ -159,24 +159,24 @@
         <%# 商品がない場合のダミー %>
         <%# 商品がある場合は表示されないようにしましょう %>
         <% unless item.presence %>
-        <li class='list'>
-            <%= link_to '#' do %>
-            <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-            <div class='item-info'>
-              <h3 class='item-name'>
-                商品を出品してね！
-              </h3>
-              <div class='item-price'>
-                <span>99999999円<br>(税込み)</span>
-                <div class='star-btn'>
-                  <%= image_tag "star.png", class:"star-icon" %>
-                  <span class='star-count'>0</span>
+          <li class='list'>
+              <%= link_to '#' do %>
+                <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+                <div class='item-info'>
+                  <h3 class='item-name'>
+                    商品を出品してね！
+                  </h3>
+                  <div class='item-price'>
+                    <span>99999999円<br>(税込み)</span>
+                    <div class='star-btn'>
+                      <%= image_tag "star.png", class:"star-icon" %>
+                      <span class='star-count'>0</span>
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
-            <%end%>
-          <%end%>
-        </li>
+              <%end%>
+            </li>
+        <%end%>
         <%# //商品がある場合は表示されないようにしましょう %>
         <%# /商品がない場合のダミー %>
       <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥<%= @item.price%>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -24,46 +24,46 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+    <% if current_user.present? && @user.id == current_user.id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%elsif current_user.present? && @user.id != current_user.id%>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%> 
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <%end%>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.detail %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%=  @user.nickname%></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.state.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @province.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%=  @day.name%></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,11 +24,11 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <% if current_user.present? && @user.id == current_user.id %>
+    <% if current_user.present? && @item.user.id == current_user.id %>
       <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <%elsif current_user.present? && @user.id != current_user.id%>
+    <%elsif current_user.present? && @item.user.id != current_user.id%>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%> 
       <%# //商品が売れていない場合はこちらを表示しましょう %>
@@ -43,7 +43,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%=  @user.nickname%></td>
+          <td class="detail-value"><%=  @item.user.nickname%></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
@@ -59,11 +59,11 @@
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= @province.name %></td>
+          <td class="detail-value"><%= @item.province.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%=  @day.name%></td>
+          <td class="detail-value"><%= @item.days.name%></td>
         </tr>
       </tbody>
     </table>
@@ -102,7 +102,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :users, only: [:edit, :update, :new, :post]
   root to: 'items#index'
-  resources :items, only: [:edit, :new, :create, :post] 
+  resources :items, only: [:edit, :new, :create, :post, :show] 
 
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :item do
     name { Faker::Name.last_name }
-    detail { Faker::Lorem.sentence}
+    detail { Faker::Lorem.sentence }
     category_id {rand(2..10)}
     state_id {rand(2..6)}
     fee_id {rand(2..2)}


### PR DESCRIPTION
# what
商品一覧にて商品をクリックした際、
詳細情報を確認できるようにした。

# why
画像をクリックすると、該当商品のページにアクセスさせる為
ユーザのログイン状況から、購入や編集など、ビューを調整

# Captured by gyazo
非ログイン
https://gyazo.com/23cfb6da1420673a66e77eb7564f02ab

非出品ユーザ
https://gyazo.com/b270111960c2118fa269be2afa44f9fc

出品ユーザ
https://gyazo.com/e4d93861815007caffaf0bc87144ca38